### PR TITLE
Fixing caret-marker height

### DIFF
--- a/src/Classes/AdornmentLayer.cs
+++ b/src/Classes/AdornmentLayer.cs
@@ -136,7 +136,7 @@ namespace SelectNextOccurrence
             }
 
             var span = new SnapshotSpan(caretPoint.GetPoint(Snapshot), 1);
-            Geometry geometry = view.TextViewLines.GetLineMarkerGeometry(span);
+            Geometry geometry = view.TextViewLines.GetTextMarkerGeometry(span);
 
             if (geometry != null)
             {


### PR DESCRIPTION
Fixing wrong height on caret-marker when selecting text on method-declarations etc. Caused when CodeLens is active and the line gets higher than the text