### PR TITLE
Fix Upper and Lower Case keyboard shortcuts

### DIFF
--- a/src/Commands/CommandTarget.cs
+++ b/src/Commands/CommandTarget.cs
@@ -138,6 +138,11 @@ namespace SelectNextOccurrence.Commands
                             Selector.IsReversing = !(Selector.Selections.All(s => !s.IsSelection()) || !Selector.IsReversing);
                             modifySelections = true;
                             break;
+                        case ((uint)VSConstants.VSStd2KCmdID.SELLOWCASE):
+                        case ((uint)VSConstants.VSStd2KCmdID.SELUPCASE):
+                            modifySelections = true;
+                            break;
+
                     }
                 }
 


### PR DESCRIPTION
Very minor change that fixes Edit.MakeUppercase and Edit.MakeLowercase shortcuts losing the selection when used.