### PR TITLE
Fix comment/uncomment commands

### DIFF
--- a/src/Commands/CommandTarget.cs
+++ b/src/Commands/CommandTarget.cs
@@ -140,9 +140,10 @@ namespace SelectNextOccurrence.Commands
                             break;
                         case ((uint)VSConstants.VSStd2KCmdID.SELLOWCASE):
                         case ((uint)VSConstants.VSStd2KCmdID.SELUPCASE):
+                        case ((uint)VSConstants.VSStd2KCmdID.COMMENT_BLOCK):
+                        case ((uint)VSConstants.VSStd2KCmdID.UNCOMMENT_BLOCK):
                             modifySelections = true;
                             break;
-
                     }
                 }
 


### PR DESCRIPTION
- Fixes Edit.CommentSelection and Edit.UncommentSelection commands behavior.
Before:
![before](https://user-images.githubusercontent.com/2589591/52455455-00a58d00-2b48-11e9-90fa-96de97c11560.gif)
After:
![after](https://user-images.githubusercontent.com/2589591/52455457-01d6ba00-2b48-11e9-834a-a39fa40aca54.gif)
