### PR TITLE
Fix selection movement and combine overlapping selections

### DIFF
--- a/src/Classes/Selection.cs
+++ b/src/Classes/Selection.cs
@@ -40,6 +40,11 @@ namespace SelectNextOccurrence
             return (Start != null && End != null);
         }
 
+        internal bool IsReversed(ITextSnapshot snapshot)
+        {
+            return Caret.GetPosition(snapshot) == Start?.GetPosition(snapshot);
+        }
+
         internal bool Reversing(ITextSnapshot snapshot)
         {
             return Caret.GetPosition(snapshot) < End?.GetPosition(snapshot);

--- a/src/Classes/Selection.cs
+++ b/src/Classes/Selection.cs
@@ -50,6 +50,51 @@ namespace SelectNextOccurrence
             return Caret.GetPosition(snapshot) < End?.GetPosition(snapshot);
         }
 
+
+        internal void SetSelection(int previousCaretPosition, ITextSnapshot Snapshot)
+        {
+            var caretPosition = Caret.GetPosition(Snapshot);
+
+            if (IsSelection())
+            {
+                var startPosition = Start.GetPosition(Snapshot);
+                var endPosition = End.GetPosition(Snapshot);
+                if (caretPosition < startPosition && startPosition < previousCaretPosition)
+                {
+                    End = Start;
+                    Start = Caret;
+                }
+                else if (previousCaretPosition < endPosition && endPosition < caretPosition)
+                {
+                    Start = End;
+                    End = Caret;
+                }
+                else if (caretPosition > startPosition && startPosition != previousCaretPosition)
+                {
+                    End = Caret;
+                }
+                else
+                {
+                    Start = Caret;
+                }
+            }
+            else
+            {
+                Start = caretPosition > previousCaretPosition ?
+                    Snapshot.CreateTrackingPoint(previousCaretPosition, PointTrackingMode.Positive)
+                    : Caret;
+
+                End = caretPosition > previousCaretPosition ?
+                    Caret
+                    : Snapshot.CreateTrackingPoint(previousCaretPosition, PointTrackingMode.Positive);
+            }
+            if (Start.GetPosition(Snapshot) == End.GetPosition(Snapshot))
+            {
+                Start = null;
+                End = null;
+            }
+        }
+
         /// <summary>
         /// Gets the caret column position when moving caret vertically.
         /// If the Caret is already on first or last line the caret is set

--- a/src/Classes/Selection.cs
+++ b/src/Classes/Selection.cs
@@ -45,12 +45,6 @@ namespace SelectNextOccurrence
             return Caret.GetPosition(snapshot) == Start?.GetPosition(snapshot);
         }
 
-        internal bool Reversing(ITextSnapshot snapshot)
-        {
-            return Caret.GetPosition(snapshot) < End?.GetPosition(snapshot);
-        }
-
-
         internal void SetSelection(int previousCaretPosition, ITextSnapshot Snapshot)
         {
             var caretPosition = Caret.GetPosition(Snapshot);

--- a/src/Classes/Selector.cs
+++ b/src/Classes/Selector.cs
@@ -393,7 +393,7 @@ namespace SelectNextOccurrence
                         selection.Start.GetPosition(Snapshot),
                         PointTrackingMode.Positive
                     );
-                    if (IsReversing)
+                    if (selection.IsReversed(Snapshot))
                     {
                         nextSelection.Caret = selection.Caret;
                     }

--- a/src/Classes/Selector.cs
+++ b/src/Classes/Selector.cs
@@ -61,12 +61,6 @@ namespace SelectNextOccurrence
         internal string SearchText;
 
         /// <summary>
-        /// An indicator wether we are selecting rtl, reversing happens in the CommandTarget
-        /// when moving to the left while selecting
-        /// </summary>
-        internal bool IsReversing = false;
-
-        /// <summary>
         /// Saves a caretposition to be added to selections at a later time
         /// Usecase is when adding the first caret by mouse-clicking, checks needs to
         /// made when releasing the cursor
@@ -213,8 +207,6 @@ namespace SelectNextOccurrence
                 if (!String.IsNullOrEmpty(editorOperations.SelectedText))
                     AddCurrentSelectionToSelections();
 
-                IsReversing = false;
-
                 return;
             }
 
@@ -268,8 +260,6 @@ namespace SelectNextOccurrence
 
                 view.Selection.Clear();
             }
-
-            IsReversing = false;
         }
 
         /// <summary>

--- a/src/Commands/CmdConvertSelectionToMultipleCursors.cs
+++ b/src/Commands/CmdConvertSelectionToMultipleCursors.cs
@@ -22,8 +22,6 @@ namespace SelectNextOccurrence.Commands
 
             if (adornmentLayer.Selector.Selections.Any())
                 adornmentLayer.DrawAdornments();
-
-            adornmentLayer.Selector.IsReversing = false;
         }
     }
 }

--- a/src/Commands/CmdSelectAllOccurrences.cs
+++ b/src/Commands/CmdSelectAllOccurrences.cs
@@ -22,8 +22,6 @@ namespace SelectNextOccurrence.Commands
 
             if (adornmentLayer.Selector.Selections.Any())
                 adornmentLayer.DrawAdornments();
-
-            adornmentLayer.Selector.IsReversing = false;
         }
     }
 }

--- a/src/Commands/CmdSelectNextExactOccurrence.cs
+++ b/src/Commands/CmdSelectNextExactOccurrence.cs
@@ -22,8 +22,6 @@ namespace SelectNextOccurrence.Commands
 
             if (adornmentLayer.Selector.Selections.Any())
                 adornmentLayer.DrawAdornments();
-
-            adornmentLayer.Selector.IsReversing = false;
         }
     }
 }

--- a/src/Commands/CmdSelectNextOccurrence.cs
+++ b/src/Commands/CmdSelectNextOccurrence.cs
@@ -22,8 +22,6 @@ namespace SelectNextOccurrence.Commands
 
             if (adornmentLayer.Selector.Selections.Any())
                 adornmentLayer.DrawAdornments();
-
-            adornmentLayer.Selector.IsReversing = false;
         }
     }
 }

--- a/src/Commands/CmdSelectPreviousExactOccurrence.cs
+++ b/src/Commands/CmdSelectPreviousExactOccurrence.cs
@@ -22,8 +22,6 @@ namespace SelectNextOccurrence.Commands
 
             if (adornmentLayer.Selector.Selections.Any())
                 adornmentLayer.DrawAdornments();
-
-            adornmentLayer.Selector.IsReversing = false;
         }
     }
 }

--- a/src/Commands/CmdSelectPreviousOccurrence.cs
+++ b/src/Commands/CmdSelectPreviousOccurrence.cs
@@ -22,8 +22,6 @@ namespace SelectNextOccurrence.Commands
 
             if (adornmentLayer.Selector.Selections.Any())
                 adornmentLayer.DrawAdornments();
-
-            adornmentLayer.Selector.IsReversing = false;
         }
     }
 }

--- a/src/Commands/CommandTarget.cs
+++ b/src/Commands/CommandTarget.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Windows;
 using Microsoft.VisualStudio;
@@ -306,8 +306,6 @@ namespace SelectNextOccurrence.Commands
 
                 selection.Caret = Snapshot.CreateTrackingPoint(position, PointTrackingMode.Positive);
 
-                view.Caret.MoveTo(selection.Caret.GetPoint(Snapshot));
-
                 if (view.Selection.IsEmpty)
                 {
                     selection.Start = null;
@@ -367,6 +365,8 @@ namespace SelectNextOccurrence.Commands
                     endPosition - startPosition
                 );
             }
+
+            view.Caret.MoveTo(Selector.Selections.Last().Caret.GetPoint(Snapshot));
 
             // Goes to caret-only mode
             if (clearSelections)


### PR DESCRIPTION
- Fixes movement with selections being inconsistent
- Combines selections that overlap with each other
- Split up selection handling logic between movement related commands and other
- Fixes default caret sometimes showing up on a wrong position
- Moved IsReversed from Selector to Selection