### PR TITLE
Fix partial selections

### DIFF
--- a/src/Classes/Selection.cs
+++ b/src/Classes/Selection.cs
@@ -45,6 +45,20 @@ namespace SelectNextOccurrence
             return Caret.GetPosition(snapshot) == Start?.GetPosition(snapshot);
         }
 
+        internal void SetCaretPosition(int position, bool verticalMove, ITextSnapshot snapshot)
+        {
+            if (verticalMove)
+            {
+                position = GetCaretColumnPosition(position, snapshot);
+            }
+            else
+            {
+                ColumnPosition = position - snapshot.GetLineFromPosition(position).Start.Position;
+            }
+
+            Caret = snapshot.CreateTrackingPoint(position, PointTrackingMode.Positive);
+        }
+
         internal void SetSelection(int previousCaretPosition, ITextSnapshot snapshot)
         {
             var caretPosition = Caret.GetPosition(snapshot);

--- a/src/Classes/Selector.cs
+++ b/src/Classes/Selector.cs
@@ -164,8 +164,10 @@ namespace SelectNextOccurrence
                 var start = Snapshot.CreateTrackingPoint(occurrence.Start, PointTrackingMode.Positive);
                 var end = Snapshot.CreateTrackingPoint(occurrence.End, PointTrackingMode.Positive);
 
+                var lastSelection = Selections.Last(s => s.IsSelection());
+
                 // If previous selection was reversed, set this caret to beginning of this selection
-                var caret = Selections.Last().Caret.GetPosition(Snapshot) == Selections.Last().Start.GetPosition(Snapshot) ?
+                var caret = lastSelection.Caret.GetPosition(Snapshot) == lastSelection.Start.GetPosition(Snapshot) ?
                     start : end;
 
                 Selections.Add(
@@ -234,18 +236,11 @@ namespace SelectNextOccurrence
                     // Start the search from previous end-position if it exists, otherwise caret
                     int startIndex;
 
-                    if (reverseDirection)
-                    {
-                        startIndex = Selections.Last().Start != null ?
-                            Selections.Last().Start.GetPosition(Snapshot)
-                            : Selections.Last().Caret.GetPosition(Snapshot);
-                    }
-                    else
-                    {
-                        startIndex = Selections.Last().End != null ?
-                            Selections.Last().End.GetPosition(Snapshot)
-                            : Selections.Last().Caret.GetPosition(Snapshot);
-                    }
+                    var lastSelection = Selections.Last(s => s.IsSelection());
+
+                    startIndex = reverseDirection ?
+                        lastSelection.Start.GetPosition(Snapshot)
+                        : lastSelection.End.GetPosition(Snapshot);
 
                     var occurrence = textSearchService.FindNext(
                         startIndex,

--- a/src/Commands/CommandTarget.cs
+++ b/src/Commands/CommandTarget.cs
@@ -305,7 +305,6 @@ namespace SelectNextOccurrence.Commands
                 else if (modifySelections)
                 {
                     selection.SetSelection(previousCaretPosition, Snapshot);
-                    view.Selection.Clear();
                 }
 
                 if (invokeCommand)
@@ -328,8 +327,6 @@ namespace SelectNextOccurrence.Commands
                             PointTrackingMode.Positive
                         );
                     }
-
-                    view.Selection.Clear();
                 }
             }
 
@@ -356,6 +353,7 @@ namespace SelectNextOccurrence.Commands
             }
 
             view.Caret.MoveTo(Selector.Selections.Last().Caret.GetPoint(Snapshot));
+            view.Selection.Clear();
 
             // Goes to caret-only mode
             if (clearSelections)

--- a/src/Commands/CommandTarget.cs
+++ b/src/Commands/CommandTarget.cs
@@ -301,10 +301,8 @@ namespace SelectNextOccurrence.Commands
                 {
                     selection.Start = null;
                     selection.End = null;
-                    modifySelections = false;
                 }
-
-                if (modifySelections)
+                else if (modifySelections)
                 {
                     selection.SetSelection(previousCaretPosition, Snapshot);
                     view.Selection.Clear();

--- a/src/Commands/CommandTarget.cs
+++ b/src/Commands/CommandTarget.cs
@@ -343,13 +343,17 @@ namespace SelectNextOccurrence.Commands
             // Set new searchtext needed if selection is modified
             if (modifySelections)
             {
-                var startPosition = Selector.Selections.Last().Start.GetPosition(Snapshot);
-                var endPosition = Selector.Selections.Last().End.GetPosition(Snapshot);
+                var lastSelection = Selector.Selections.LastOrDefault(n => n.IsSelection());
+                if (lastSelection != null)
+                {
+                    var startPosition = lastSelection.Start.GetPosition(Snapshot);
+                    var endPosition = lastSelection.End.GetPosition(Snapshot);
 
-                Selector.SearchText = Snapshot.GetText(
-                    startPosition,
-                    endPosition - startPosition
-                );
+                    Selector.SearchText = Snapshot.GetText(
+                        startPosition,
+                        endPosition - startPosition
+                    );
+                }
             }
 
             view.Caret.MoveTo(Selector.Selections.Last().Caret.GetPoint(Snapshot));

--- a/src/Commands/CommandTarget.cs
+++ b/src/Commands/CommandTarget.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Windows;
 using Microsoft.VisualStudio;
@@ -294,17 +294,8 @@ namespace SelectNextOccurrence.Commands
                 result = NextCommandTarget.Exec(ref pguidCmdGroup, nCmdID, nCmdexecopt, pvaIn, pvaOut);
 
                 var position = view.Caret.Position.BufferPosition.Position;
-                if (verticalMove)
-                {
-                    position = selection.GetCaretColumnPosition(position, Snapshot);
-                }
-                else
-                {
-                    var caretLine = Snapshot.GetLineFromPosition(position);
-                    selection.ColumnPosition = position - caretLine.Start.Position;
-                }
 
-                selection.Caret = Snapshot.CreateTrackingPoint(position, PointTrackingMode.Positive);
+                selection.SetCaretPosition(position, verticalMove, Snapshot);
 
                 if (view.Selection.IsEmpty)
                 {


### PR DESCRIPTION
Fixes empty selections affecting later selections by setting modifySelections variable to false.
Fixes search text for next occurrence trying to use last selection when its empty.
And other minor refactors.