### PR TITLE
Fix line movement

### DIFF
--- a/src/Classes/Selector.cs
+++ b/src/Classes/Selector.cs
@@ -321,6 +321,8 @@ namespace SelectNextOccurrence
                 EditorOperations.MoveLineUp(false);
                 AddCurrentCaretToSelections();
             }
+            Selections = Selections.OrderBy(n => n.Caret.GetPosition(Snapshot)).ToList();
+            View.Caret.MoveTo(Selections.First().Caret.GetPoint(Snapshot));
         }
 
         internal void AddCaretBelow()
@@ -331,6 +333,8 @@ namespace SelectNextOccurrence
                 EditorOperations.MoveLineDown(false);
                 AddCurrentCaretToSelections();
             }
+            Selections = Selections.OrderBy(n => n.Caret.GetPosition(Snapshot)).ToList();
+            View.Caret.MoveTo(Selections.Last().Caret.GetPoint(Snapshot));
         }
 
         internal void AddCurrentCaretToSelections()


### PR DESCRIPTION
Fixes Edit.MoveSelectedLinesUp and Edit.MoveSelectedLinesDown when adding caret above and when mixing adding caret above and below. Also moves the default caret position to first caret or last caret when adding caret above or below respectively.


**After/Before Add caret above + move lines**
![addcaretabove](https://user-images.githubusercontent.com/2589591/53311167-b2162380-38a7-11e9-9b87-b05ec359d26b.gif)


**After/Before Add caret above & below + move lines**
![combinedmove](https://user-images.githubusercontent.com/2589591/53311169-b3dfe700-38a7-11e9-9321-12acc8e0a334.gif)

