### PR TITLE
Added end of word selection

### DIFF
--- a/src/Classes/Selector.cs
+++ b/src/Classes/Selector.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using EnvDTE;
@@ -260,15 +260,23 @@ namespace SelectNextOccurrence
         {
             EditorOperations.SelectCurrentWord();
 
-            if (string.IsNullOrEmpty(EditorOperations.SelectedText))
+            var selectedText = EditorOperations.SelectedText;
+
+            if (string.IsNullOrEmpty(selectedText))
                 return;
 
-            if (EditorOperations.SelectedText.Length == 1 && GetCurrentColumnPosition(caretPosition) != 0)
+            if (selectedText.Length == 1
+                && !char.IsLetterOrDigit(selectedText[0])
+                && GetCurrentColumnPosition(caretPosition) != 0)
             {
                 View.Caret.MoveTo(caretPosition - 1);
                 EditorOperations.SelectCurrentWord();
 
-                if (EditorOperations.SelectedText.Length <= 1)
+                selectedText = EditorOperations.SelectedText;
+
+                if (selectedText.Length == 0
+                    || (selectedText.Length == 1
+                    && !char.IsLetterOrDigit(selectedText[0])))
                 {
                     View.Caret.MoveTo(caretPosition);
                     EditorOperations.SelectCurrentWord();

--- a/src/Classes/Selector.cs
+++ b/src/Classes/Selector.cs
@@ -262,11 +262,10 @@ namespace SelectNextOccurrence
 
             var selectedText = EditorOperations.SelectedText;
 
-            if (string.IsNullOrEmpty(selectedText))
+            if (selectedText.Length == 0)
                 return;
 
-            if (selectedText.Length == 1
-                && !char.IsLetterOrDigit(selectedText[0])
+            if (!char.IsLetterOrDigit(selectedText[0])
                 && GetCurrentColumnPosition(caretPosition) != 0)
             {
                 View.Caret.MoveTo(caretPosition - 1);
@@ -274,9 +273,7 @@ namespace SelectNextOccurrence
 
                 selectedText = EditorOperations.SelectedText;
 
-                if (selectedText.Length == 0
-                    || (selectedText.Length == 1
-                    && !char.IsLetterOrDigit(selectedText[0])))
+                if (selectedText.Length == 0 || !char.IsLetterOrDigit(selectedText[0]))
                 {
                     View.Caret.MoveTo(caretPosition);
                     EditorOperations.SelectCurrentWord();

--- a/src/Classes/Selector.cs
+++ b/src/Classes/Selector.cs
@@ -260,22 +260,17 @@ namespace SelectNextOccurrence
         {
             EditorOperations.SelectCurrentWord();
 
-            var selectedText = EditorOperations.SelectedText;
-
-            if (selectedText.Length == 0)
+            if (EditorOperations.SelectedText.Length == 0)
                 return;
 
-            if (!char.IsLetterOrDigit(selectedText[0])
+            if (!char.IsLetterOrDigit(EditorOperations.SelectedText[0])
                 && GetCurrentColumnPosition(caretPosition) != 0)
             {
-                View.Caret.MoveTo(caretPosition - 1);
-                EditorOperations.SelectCurrentWord();
+                var previousChar = Snapshot.ToCharArray(caretPosition - 1, 1);
 
-                selectedText = EditorOperations.SelectedText;
-
-                if (selectedText.Length == 0 || !char.IsLetterOrDigit(selectedText[0]))
+                if (char.IsLetterOrDigit(previousChar[0]))
                 {
-                    View.Caret.MoveTo(caretPosition);
+                    View.Caret.MoveTo(caretPosition - 1);
                     EditorOperations.SelectCurrentWord();
                 }
             }

--- a/src/Classes/Selector.cs
+++ b/src/Classes/Selector.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using EnvDTE;
@@ -201,11 +201,7 @@ namespace SelectNextOccurrence
             // Caret placed on a word, but nothing selected
             if (!Selections.Any() && View.Selection.IsEmpty)
             {
-                EditorOperations.SelectCurrentWord();
-
-                if (!string.IsNullOrEmpty(EditorOperations.SelectedText))
-                    AddCurrentSelectionToSelections();
-
+                SelectCurrentWord(View.Caret.Position.BufferPosition);
                 return;
             }
 
@@ -225,8 +221,7 @@ namespace SelectNextOccurrence
                     foreach (var selection in oldSelections)
                     {
                         View.Caret.MoveTo(selection.Caret.GetPoint(Snapshot));
-                        EditorOperations.SelectCurrentWord();
-                        AddCurrentSelectionToSelections();
+                        SelectCurrentWord(selection.Caret.GetPoint(Snapshot));
                     }
                 }
                 else
@@ -259,6 +254,28 @@ namespace SelectNextOccurrence
 
                 View.Selection.Clear();
             }
+        }
+
+        private void SelectCurrentWord(SnapshotPoint caretPosition)
+        {
+            EditorOperations.SelectCurrentWord();
+
+            if (string.IsNullOrEmpty(EditorOperations.SelectedText))
+                return;
+
+            if (EditorOperations.SelectedText.Length == 1 && GetCurrentColumnPosition(caretPosition) != 0)
+            {
+                View.Caret.MoveTo(caretPosition - 1);
+                EditorOperations.SelectCurrentWord();
+
+                if (EditorOperations.SelectedText.Length <= 1)
+                {
+                    View.Caret.MoveTo(caretPosition);
+                    EditorOperations.SelectCurrentWord();
+                }
+            }
+
+            AddCurrentSelectionToSelections();
         }
 
         /// <summary>


### PR DESCRIPTION
Added end of word selection when the EditorOperations.SelectCurrenctWord() returns a non alphanumeric result. Checks if a the caret is at an end of a word and selects that instead.
This is more inline how both VS Code and Sublime handles these selections.

**Before/After**
![endofwordselection](https://user-images.githubusercontent.com/2589591/53461432-6f378580-3a38-11e9-85a3-680922e60e8e.gif)
