### PR TITLE
Add virtual space support

### DIFF
--- a/src/Classes/AdornmentLayer.cs
+++ b/src/Classes/AdornmentLayer.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Shapes;
@@ -152,7 +152,7 @@ namespace SelectNextOccurrence
                     Margin = new System.Windows.Thickness(0, 0, 0, 0),
                 };
 
-                Canvas.SetLeft(rectangle, geometry.Bounds.Left + (selection.VirtualSpaces * drawing.Bounds.Width));
+                Canvas.SetLeft(rectangle, geometry.Bounds.Left + (selection.VirtualSpaces * view.TextViewLines[0].VirtualSpaceWidth));
                 Canvas.SetTop(rectangle, geometry.Bounds.Top);
 
                 layer.AddAdornment(AdornmentPositioningBehavior.TextRelative, span, Vsix.Name, rectangle, null);

--- a/src/Classes/AdornmentLayer.cs
+++ b/src/Classes/AdornmentLayer.cs
@@ -120,22 +120,20 @@ namespace SelectNextOccurrence
             {
                 foreach (var selection in Selector.Selections)
                 {
-                    if (selection.Start != null && selection.End != null)
+                    if (selection.IsSelection())
                         DrawSelection(selection);
 
-                    DrawCaret(selection.Caret);
+                    DrawCaret(selection);
                 }
             }
         }
 
-        private void DrawCaret(ITrackingPoint caretPoint)
+        private void DrawCaret(Selection selection)
         {
-            if (caretPoint.GetPosition(Snapshot) >= Snapshot.Length)
-            {
+            if (selection.Caret.GetPosition(Snapshot) >= Snapshot.Length)
                 return;
-            }
 
-            var span = new SnapshotSpan(caretPoint.GetPoint(Snapshot), 1);
+            var span = new SnapshotSpan(selection.Caret.GetPoint(Snapshot), 1);
             var geometry = view.TextViewLines.GetTextMarkerGeometry(span);
 
             if (geometry != null)
@@ -154,7 +152,7 @@ namespace SelectNextOccurrence
                     Margin = new System.Windows.Thickness(0, 0, 0, 0),
                 };
 
-                Canvas.SetLeft(rectangle, geometry.Bounds.Left);
+                Canvas.SetLeft(rectangle, geometry.Bounds.Left + (selection.VirtualSpaces * drawing.Bounds.Width));
                 Canvas.SetTop(rectangle, geometry.Bounds.Top);
 
                 layer.AddAdornment(AdornmentPositioningBehavior.TextRelative, span, Vsix.Name, rectangle, null);
@@ -183,7 +181,7 @@ namespace SelectNextOccurrence
                 var drawingImage = new DrawingImage(drawing);
                 drawingImage.Freeze();
 
-                var image = new System.Windows.Controls.Image
+                var image = new Image
                 {
                     Source = drawingImage,
                 };

--- a/src/Classes/MouseProcessor.cs
+++ b/src/Classes/MouseProcessor.cs
@@ -46,7 +46,7 @@ namespace SelectNextOccurrence
                     if (AdornmentLayer.Selector.StashedCaret != null)
                         AdornmentLayer.Selector.ApplyStashedCaretPosition();
 
-                    AdornmentLayer.Selector.AddCurrentCaretToSelections();
+                    AdornmentLayer.Selector.AddMouseCaretToSelections();
                 }
                 else
                 {

--- a/src/Classes/Selection.cs
+++ b/src/Classes/Selection.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text;
 
 namespace SelectNextOccurrence
 {
@@ -59,7 +59,7 @@ namespace SelectNextOccurrence
             Caret = snapshot.CreateTrackingPoint(position, PointTrackingMode.Positive);
         }
 
-        internal void SetSelection(int previousCaretPosition, ITextSnapshot snapshot)
+        internal void UpdateSelection(int previousCaretPosition, ITextSnapshot snapshot)
         {
             var caretPosition = Caret.GetPosition(snapshot);
 
@@ -101,6 +101,23 @@ namespace SelectNextOccurrence
                 Start = null;
                 End = null;
             }
+        }
+
+        internal void SetSelection(VirtualSnapshotSpan newSpan, ITextSnapshot snapshot)
+        {
+            Start = snapshot.CreateTrackingPoint(
+                newSpan.Start.Position.Position > newSpan.End.Position.Position ?
+                newSpan.End.Position.Position
+                : newSpan.Start.Position.Position,
+                PointTrackingMode.Positive
+            );
+
+            End = snapshot.CreateTrackingPoint(
+                newSpan.Start.Position.Position > newSpan.End.Position.Position ?
+                newSpan.Start.Position.Position
+                : newSpan.End.Position.Position,
+                PointTrackingMode.Positive
+            );
         }
 
         /// <summary>

--- a/src/Classes/Selection.cs
+++ b/src/Classes/Selection.cs
@@ -13,11 +13,18 @@ namespace SelectNextOccurrence
 
         internal int ColumnPosition { get; set; }
 
+        internal int VirtualSpaces { get; set; }
+
         /// <summary>
         /// Contains the copied/cut text of the current selection for use in the same document when pasting into the same active cursors.
         /// When pasting across documents the static <see cref="Selector.SavedClipboard"/> is used
         /// </summary>
         internal string CopiedText { get; set; }
+
+        internal VirtualSnapshotPoint GetVirtualPoint(ITextSnapshot snapshot)
+        {
+            return new VirtualSnapshotPoint(Caret.GetPoint(snapshot), VirtualSpaces);
+        }
 
         internal bool OverlapsWith(SnapshotSpan span, ITextSnapshot snapshot)
         {

--- a/src/Classes/Selection.cs
+++ b/src/Classes/Selection.cs
@@ -84,7 +84,7 @@ namespace SelectNextOccurrence
                     Start = End;
                     End = Caret;
                 }
-                else if (caretPosition > startPosition && startPosition != previousCaretPosition)
+                else if (caretPosition >= startPosition && startPosition != previousCaretPosition)
                 {
                     End = Caret;
                 }

--- a/src/Classes/Selector.cs
+++ b/src/Classes/Selector.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using EnvDTE;
 using EnvDTE80;
@@ -115,7 +115,8 @@ namespace SelectNextOccurrence
                     Start = Snapshot.CreateTrackingPoint(start, PointTrackingMode.Positive),
                     End = Snapshot.CreateTrackingPoint(end, PointTrackingMode.Positive),
                     Caret = Snapshot.CreateTrackingPoint(caret, PointTrackingMode.Positive),
-                    ColumnPosition = GetCurrentColumnPosition(caret)
+                    ColumnPosition = GetCurrentColumnPosition(caret),
+                    VirtualSpaces = View.Caret.Position.VirtualSpaces
                 }
             );
 
@@ -377,7 +378,8 @@ namespace SelectNextOccurrence
                             caretPosition,
                             PointTrackingMode.Positive
                         ),
-                        ColumnPosition = GetCurrentColumnPosition(caretPosition)
+                        ColumnPosition = GetCurrentColumnPosition(caretPosition),
+                        VirtualSpaces = View.Caret.Position.VirtualSpaces
                     }
                 );
             }

--- a/src/Commands/CommandTarget.cs
+++ b/src/Commands/CommandTarget.cs
@@ -324,29 +324,11 @@ namespace SelectNextOccurrence.Commands
                 }
                 else if (modifySelections)
                 {
-                    selection.SetSelection(previousCaretPosition, Snapshot);
+                    selection.UpdateSelection(previousCaretPosition, Snapshot);
                 }
-
-                if (invokeCommand)
+                else if (invokeCommand)
                 {
-                    var newSpan = view.Selection.StreamSelectionSpan;
-
-                    if (!view.Selection.IsEmpty)
-                    {
-                        selection.Start = Snapshot.CreateTrackingPoint(
-                            newSpan.Start.Position.Position > newSpan.End.Position.Position ?
-                            newSpan.End.Position.Position
-                            : newSpan.Start.Position.Position,
-                            PointTrackingMode.Positive
-                        );
-
-                        selection.End = Snapshot.CreateTrackingPoint(
-                            newSpan.Start.Position.Position > newSpan.End.Position.Position ?
-                            newSpan.Start.Position.Position
-                            : newSpan.End.Position.Position,
-                            PointTrackingMode.Positive
-                        );
-                    }
+                    selection.SetSelection(view.Selection.StreamSelectionSpan, Snapshot);
                 }
                 view.Selection.Clear();
             }

--- a/src/Commands/CommandTarget.cs
+++ b/src/Commands/CommandTarget.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Windows;
 using Microsoft.VisualStudio;
@@ -159,7 +159,8 @@ namespace SelectNextOccurrence.Commands
 
                 if (pguidCmdGroup == PackageGuids.guidNextOccurrenceCommandsPackageCmdSet)
                 {
-                    verticalMove = nCmdID == 304 || nCmdID == 305;
+                    verticalMove = nCmdID == PackageIds.AddCaretAboveCommandId
+                        || nCmdID == PackageIds.AddCaretBelowCommandId;
                 }
             }
             else if (pguidCmdGroup == PackageGuids.guidExtensionSubWordNavigation)

--- a/src/Commands/CommandTarget.cs
+++ b/src/Commands/CommandTarget.cs
@@ -156,6 +156,11 @@ namespace SelectNextOccurrence.Commands
                         processOrder = ProcessOrder.BottomToTop;
                         break;
                 }
+
+                if (pguidCmdGroup == PackageGuids.guidNextOccurrenceCommandsPackageCmdSet)
+                {
+                    verticalMove = nCmdID == 304 || nCmdID == 305;
+                }
             }
             else if (pguidCmdGroup == PackageGuids.guidExtensionSubWordNavigation)
             {
@@ -319,11 +324,9 @@ namespace SelectNextOccurrence.Commands
 
                 result = NextCommandTarget.Exec(ref pguidCmdGroup, nCmdID, nCmdexecopt, pvaIn, pvaOut);
 
-                selection.VirtualSpaces = view.Caret.InVirtualSpace ? view.Caret.Position.VirtualSpaces : 0;
+                selection.VirtualSpaces = view.Caret.Position.VirtualSpaces;
 
-                var position = view.Caret.Position.BufferPosition.Position;
-
-                selection.SetCaretPosition(position, verticalMove, Snapshot);
+                selection.SetCaretPosition(view.Caret.Position.BufferPosition, verticalMove, Snapshot);
 
                 if (view.Selection.IsEmpty)
                 {
@@ -349,7 +352,7 @@ namespace SelectNextOccurrence.Commands
             if (Selector.Dte.UndoContext.IsOpen)
                 Selector.Dte.UndoContext.Close();
 
-            // Set new searchtext needed if selection is modified
+            // Set new search text. Needed if selection is modified
             if (modifySelections)
             {
                 var lastSelection = Selector.Selections.Last();

--- a/src/Commands/CommandTarget.cs
+++ b/src/Commands/CommandTarget.cs
@@ -306,12 +306,20 @@ namespace SelectNextOccurrence.Commands
                         selection.IsReversed(Snapshot)
                     );
                 }
-
-                view.Caret.MoveTo(selection.Caret.GetPoint(Snapshot));
+                if (selection.VirtualSpaces == 0)
+                {
+                    view.Caret.MoveTo(selection.Caret.GetPoint(Snapshot));
+                }
+                else
+                {
+                    view.Caret.MoveTo(selection.GetVirtualPoint(Snapshot));
+                }
 
                 var previousCaretPosition = selection.Caret.GetPosition(Snapshot);
 
                 result = NextCommandTarget.Exec(ref pguidCmdGroup, nCmdID, nCmdexecopt, pvaIn, pvaOut);
+
+                selection.VirtualSpaces = view.Caret.InVirtualSpace ? view.Caret.Position.VirtualSpaces : 0;
 
                 var position = view.Caret.Position.BufferPosition.Position;
 
@@ -357,7 +365,7 @@ namespace SelectNextOccurrence.Commands
                 }
             }
 
-            view.Caret.MoveTo(Selector.Selections.Last().Caret.GetPoint(Snapshot));
+            view.Caret.MoveTo(Selector.Selections.Last().GetVirtualPoint(Snapshot));
             view.Selection.Clear();
 
             // Goes to caret-only mode


### PR DESCRIPTION
Added virtual space support when moving the caret or adding caret with the mouse.
Updated add caret above/below to store the column position from the caret it was created from.
Also fixed some minor issues with selections and final caret position and refactored the code a bit.