### PR TITLE
Fix: SearchCombo command passing through

### DIFF
--- a/src/Commands/CommandTarget.cs
+++ b/src/Commands/CommandTarget.cs
@@ -57,6 +57,7 @@ namespace SelectNextOccurrence.Commands
                 switch ((VSConstants.VSStd97CmdID) nCmdID)
                 {
                     case VSConstants.VSStd97CmdID.SolutionCfg:
+                    case VSConstants.VSStd97CmdID.SearchCombo:
                         return result;
                 }
             }


### PR DESCRIPTION
Fixes VSConstants.VSStd97CmdID.SearchCombo passing through and messing with column position of each caret.
This issue is at least prevalent in VS 2019.