### PR TITLE
BugFix: Select Next Occurrence on empty lines

### DIFF
--- a/src/Classes/Selector.cs
+++ b/src/Classes/Selector.cs
@@ -265,18 +265,18 @@ namespace SelectNextOccurrence
         {
             EditorOperations.SelectCurrentWord();
 
-            if (EditorOperations.SelectedText.Length == 0)
-                return;
-
-            if (!char.IsLetterOrDigit(EditorOperations.SelectedText[0])
-                && Snapshot.GetLineColumnFromPosition(caretPosition) != 0)
+            if (EditorOperations.SelectedText.Length != 0)
             {
-                var previousChar = Snapshot.ToCharArray(caretPosition - 1, 1)[0];
-
-                if (char.IsLetterOrDigit(previousChar))
+                if (!char.IsLetterOrDigit(EditorOperations.SelectedText[0])
+                    && Snapshot.GetLineColumnFromPosition(caretPosition) != 0)
                 {
-                    View.Caret.MoveTo(caretPosition - 1);
-                    EditorOperations.SelectCurrentWord();
+                    var previousChar = Snapshot.ToCharArray(caretPosition - 1, 1)[0];
+
+                    if (char.IsLetterOrDigit(previousChar))
+                    {
+                        View.Caret.MoveTo(caretPosition - 1);
+                        EditorOperations.SelectCurrentWord();
+                    }
                 }
             }
 

--- a/src/Commands/CommandTarget.cs
+++ b/src/Commands/CommandTarget.cs
@@ -180,11 +180,11 @@ namespace SelectNextOccurrence.Commands
                         break;
                 }
 
-                if (pguidCmdGroup == PackageGuids.guidNextOccurrenceCommandsPackageCmdSet)
-                {
-                    verticalMove = nCmdID == PackageIds.AddCaretAboveCommandId
-                                   || nCmdID == PackageIds.AddCaretBelowCommandId;
-                }
+            }
+            else if (pguidCmdGroup == PackageGuids.guidNextOccurrenceCommandsPackageCmdSet)
+            {
+                verticalMove = nCmdID == PackageIds.AddCaretAboveCommandId
+                                || nCmdID == PackageIds.AddCaretBelowCommandId;
             }
 
             if (Selector.Selections.Any())


### PR DESCRIPTION
Fixes when using select next occurrence command on empty line while in multi caret mode causing an error popup.
![sE9EaT3vJe](https://user-images.githubusercontent.com/2589591/58378824-166d7f80-7f8a-11e9-81b2-194cc79316ef.gif)
