### PR TITLE
Fixes column position calculation with tabs characters

### DIFF
--- a/src/Classes/AdornmentLayer.cs
+++ b/src/Classes/AdornmentLayer.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
@@ -170,14 +170,11 @@ namespace SelectNextOccurrence
                 geometry = view.TextViewLines.GetTextMarkerGeometry(span);
                 if (geometry != null)
                 {
-                    drawing = new GeometryDrawing(caretBrush, null, geometry);
-                    drawing.Freeze();
-
                     element = new Rectangle
                     {
                         Fill = caretBrush,
-                        Width = drawing.Bounds.Width / 6,
-                        Height = drawing.Bounds.Height,
+                        Width = view.FormattedLineSource.ColumnWidth / 6,
+                        Height = view.FormattedLineSource.LineHeight,
                         Margin = new Thickness(0, 0, 0, 0),
                     };
 

--- a/src/Classes/MouseProcessor.cs
+++ b/src/Classes/MouseProcessor.cs
@@ -44,8 +44,10 @@ namespace SelectNextOccurrence
                 if (ExtensionOptions.Instance.AddMouseCursors && CheckModifiers())
                 {
                     if (AdornmentLayer.Selector.StashedCaret != null)
-                        AdornmentLayer.Selector.ApplyStashedCaretPosition();
-
+                    {
+                        var previousPosition = AdornmentLayer.Selector.ApplyStashedCaretPosition();
+                        AdornmentLayer.Selector.MoveToPosition(previousPosition);
+                    }
                     AdornmentLayer.Selector.AddMouseCaretToSelections();
                 }
                 else

--- a/src/Classes/Selection.cs
+++ b/src/Classes/Selection.cs
@@ -50,23 +50,6 @@ namespace SelectNextOccurrence
             return Caret.GetPosition(snapshot) == Start?.GetPosition(snapshot);
         }
 
-        internal void SetCaretPosition(CaretPosition caretPosition, bool verticalMove, int columnPosition, ITextSnapshot snapshot)
-        {
-            var position = caretPosition.BufferPosition.Position;
-
-            if (verticalMove)
-            {
-                position = GetCaretColumnPosition(position, snapshot);
-            }
-            else
-            {
-                ColumnPosition = columnPosition;
-            }
-
-            Caret = snapshot.CreateTrackingPoint(position);
-            VirtualSpaces = caretPosition.VirtualSpaces;
-        }
-
         internal void UpdateSelection(int previousCaretPosition, ITextSnapshot snapshot)
         {
             var caretPosition = Caret.GetPosition(snapshot);
@@ -136,7 +119,7 @@ namespace SelectNextOccurrence
         /// <param name="caretPosition"></param>
         /// <param name="snapshot"></param>
         /// <returns></returns>
-        internal int GetCaretColumnPosition(int caretPosition, ITextSnapshot snapshot)
+        internal int GetCaretColumnPosition(int caretPosition, ITextSnapshot snapshot, int tabSize)
         {
             var previousLineNumber = snapshot.GetLineNumberFromPosition(Caret.GetPosition(snapshot));
             var caretLine = snapshot.GetLineFromPosition(caretPosition);
@@ -152,7 +135,7 @@ namespace SelectNextOccurrence
             }
             else if (ColumnPosition > ( caretPosition - caretLine.Start.Position ))
             {
-                return caretLine.Start.Position + ColumnOffset(caretLine.GetText());
+                return caretLine.Start.Position + ColumnOffset(caretLine.GetText(), tabSize);
             }
             else
             {
@@ -160,7 +143,7 @@ namespace SelectNextOccurrence
             }
         }
 
-        private int ColumnOffset(string lineText)
+        private int ColumnOffset(string lineText, int tabSize)
         {
             var caretOffset = 0;
             if (lineText.Length != 0)
@@ -168,7 +151,7 @@ namespace SelectNextOccurrence
                 var yPosition = 0;
                 do
                 {
-                    yPosition += lineText[caretOffset] == '\t' ? 4 : 1;
+                    yPosition += lineText[caretOffset] == '\t' ? tabSize : 1;
                     caretOffset++;
                 }
                 while (yPosition < ColumnPosition && caretOffset < lineText.Length);

--- a/src/Classes/Selection.cs
+++ b/src/Classes/Selection.cs
@@ -50,7 +50,7 @@ namespace SelectNextOccurrence
             return Caret.GetPosition(snapshot) == Start?.GetPosition(snapshot);
         }
 
-        internal void SetCaretPosition(CaretPosition caretPosition, bool verticalMove, ITextSnapshot snapshot)
+        internal void SetCaretPosition(CaretPosition caretPosition, bool verticalMove, int columnPosition, ITextSnapshot snapshot)
         {
             var position = caretPosition.BufferPosition.Position;
 
@@ -60,7 +60,7 @@ namespace SelectNextOccurrence
             }
             else
             {
-                ColumnPosition = position - snapshot.GetLineFromPosition(position).Start.Position;
+                ColumnPosition = columnPosition;
             }
 
             Caret = snapshot.CreateTrackingPoint(position);
@@ -152,15 +152,29 @@ namespace SelectNextOccurrence
             }
             else if (ColumnPosition > ( caretPosition - caretLine.Start.Position ))
             {
-                var correctColumnPosition = ( ColumnPosition > caretLine.Length ) ?
-                    caretLine.Length
-                    : ColumnPosition;
-                return caretLine.Start.Position + correctColumnPosition;
+                return caretLine.Start.Position + ColumnOffset(caretLine.GetText());
             }
             else
             {
                 return caretPosition;
             }
+        }
+
+        private int ColumnOffset(string lineText)
+        {
+            var caretOffset = 0;
+            if (lineText.Length != 0)
+            {
+                var yPosition = 0;
+                do
+                {
+                    yPosition += lineText[caretOffset] == '\t' ? 4 : 1;
+                    caretOffset++;
+                }
+                while (yPosition < ColumnPosition && caretOffset < lineText.Length);
+            }
+
+            return caretOffset;
         }
     }
 }

--- a/src/Classes/Selector.cs
+++ b/src/Classes/Selector.cs
@@ -379,7 +379,10 @@ namespace SelectNextOccurrence
                 VirtualSpaces = view.Caret.Position.VirtualSpaces
             };
 
-            var newPosition = newSelection.GetCaretColumnPosition(caretPosition, Snapshot);
+            var newPosition = newSelection.GetCaretColumnPosition(
+                caretPosition,
+                Snapshot,
+                view.FormattedLineSource.TabSize);
             newSelection.Caret = Snapshot.CreateTrackingPoint(newPosition);
 
             if (Selections.Any(s => s.Caret.GetPoint(Snapshot) == newPosition))

--- a/src/Classes/Selector.cs
+++ b/src/Classes/Selector.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using EnvDTE;
 using EnvDTE80;
@@ -116,7 +117,7 @@ namespace SelectNextOccurrence
                     Start = Snapshot.CreateTrackingPoint(start),
                     End = Snapshot.CreateTrackingPoint(end),
                     Caret = Snapshot.CreateTrackingPoint(caret),
-                    ColumnPosition = Snapshot.GetLineColumnFromPosition(caret),
+                    ColumnPosition = GetColumnPosition(),
                     VirtualSpaces = view.Caret.Position.VirtualSpaces
                 }
             );
@@ -164,19 +165,19 @@ namespace SelectNextOccurrence
                 var caret = Selections.Last().IsReversed(Snapshot)
                     ? start : end;
 
+                view.Caret.MoveTo(caret == start ? occurrence.Start : occurrence.End);
+
                 Selections.Add(
                     new Selection
                     {
                         Start = start,
                         End = end,
                         Caret = caret,
-                        ColumnPosition = Snapshot.GetLineColumnFromPosition(caret.GetPoint(Snapshot))
+                        ColumnPosition = GetColumnPosition()
                     }
                 );
 
                 outliningManager.ExpandAll(occurrence, r => r.IsCollapsed);
-
-                view.Caret.MoveTo(caret == start ? occurrence.Start : occurrence.End);
 
                 view.ViewScroller.EnsureSpanVisible(
                     new SnapshotSpan(view.Caret.Position.BufferPosition, 0)
@@ -308,28 +309,32 @@ namespace SelectNextOccurrence
             var beginLineNumber = view.Selection.Start.Position.GetContainingLine().LineNumber;
             var endLineNumber = view.Selection.End.Position.GetContainingLine().LineNumber;
 
+            var currentPosition = view.Caret.Position.BufferPosition;
             if (beginLineNumber != endLineNumber)
             {
                 for (var lineNumber = beginLineNumber; lineNumber < endLineNumber; lineNumber++)
                 {
                     var line = Snapshot.GetLineFromLineNumber(lineNumber);
+                    view.Caret.MoveTo(line.End);
                     Selections.Add(
                         new Selection
                         {
                             Caret = Snapshot.CreateTrackingPoint(line.End.Position),
-                            ColumnPosition = Snapshot.GetLineColumnFromPosition(line.End.Position)
+                            ColumnPosition = GetColumnPosition(),
                         }
                     );
                 }
 
+                view.Caret.MoveTo(view.Selection.End.Position);
                 Selections.Add(
                     new Selection
                     {
                         Caret = Snapshot.CreateTrackingPoint(view.Selection.End.Position),
-                        ColumnPosition = Snapshot.GetLineColumnFromPosition(view.Selection.End.Position)
+                        ColumnPosition = GetColumnPosition()
                     }
                 );
 
+                view.Caret.MoveTo(currentPosition);
                 view.Selection.Clear();
             }
             else
@@ -392,8 +397,7 @@ namespace SelectNextOccurrence
                 var newSelection = new Selection
                 {
                     Caret = Snapshot.CreateTrackingPoint(caretPosition),
-                    ColumnPosition = Snapshot.GetLineColumnFromPosition(caretPosition)
-                        + view.Caret.Position.VirtualSpaces,
+                    ColumnPosition = GetColumnPosition() + view.Caret.Position.VirtualSpaces,
                     VirtualSpaces = view.Caret.Position.VirtualSpaces
                 };
 
@@ -416,10 +420,8 @@ namespace SelectNextOccurrence
                 Selections.Add(
                     new Selection
                     {
-                        Start = null,
-                        End = null,
                         Caret = Snapshot.CreateTrackingPoint(caretPosition),
-                        ColumnPosition = Snapshot.GetLineColumnFromPosition(caretPosition)
+                        ColumnPosition = GetColumnPosition()
                     }
                 );
             }
@@ -520,6 +522,12 @@ namespace SelectNextOccurrence
             }
         }
 
+        internal int GetColumnPosition()
+        {
+            var lineSource = view.FormattedLineSource;
+            return Convert.ToInt32(( view.Caret.Left - lineSource.BaseIndentation ) / lineSource.ColumnWidth);
+        }
+
         internal string GetCurrentlySelectedText()
         {
             return EditorOperations.SelectedText;
@@ -541,24 +549,31 @@ namespace SelectNextOccurrence
             StashedCaret = null;
         }
 
-        internal void ApplyStashedCaretPosition()
+        internal SnapshotPoint ApplyStashedCaretPosition()
         {
             var stashedCaretPosition = StashedCaret.GetPosition(Snapshot);
+
+            var position = view.Caret.Position.BufferPosition;
+
+            view.Caret.MoveTo(StashedCaret.GetPoint(Snapshot));
 
             if (!Selections.Any(s => s.Caret.GetPoint(Snapshot) == stashedCaretPosition))
             {
                 Selections.Add(
                     new Selection
                     {
-                        Start = null,
-                        End = null,
                         Caret = StashedCaret,
-                        ColumnPosition = Snapshot.GetLineColumnFromPosition(stashedCaretPosition)
+                        ColumnPosition = GetColumnPosition()
                     }
                 );
             }
-
             StashedCaret = null;
+            return position;
+        }
+
+        internal void MoveToPosition(SnapshotPoint position)
+        {
+            view.Caret.MoveTo(position);
         }
         #endregion
 

--- a/src/Commands/CommandTarget.cs
+++ b/src/Commands/CommandTarget.cs
@@ -317,7 +317,7 @@ namespace SelectNextOccurrence.Commands
 
                 result = NextCommandTarget.Exec(ref pguidCmdGroup, nCmdID, nCmdexecopt, pvaIn, pvaOut);
 
-                selection.SetCaretPosition(view.Caret.Position, verticalMove, Snapshot);
+                selection.SetCaretPosition(view.Caret.Position, verticalMove, Selector.GetColumnPosition(), Snapshot);
 
                 if (view.Selection.IsEmpty)
                 {

--- a/src/Commands/CommandTarget.cs
+++ b/src/Commands/CommandTarget.cs
@@ -317,7 +317,17 @@ namespace SelectNextOccurrence.Commands
 
                 result = NextCommandTarget.Exec(ref pguidCmdGroup, nCmdID, nCmdexecopt, pvaIn, pvaOut);
 
-                selection.SetCaretPosition(view.Caret.Position, verticalMove, Selector.GetColumnPosition(), Snapshot);
+                var position = view.Caret.Position.BufferPosition.Position;
+                if (verticalMove)
+                {
+                    position = selection.GetCaretColumnPosition(position, Snapshot, view.FormattedLineSource.TabSize);
+                }
+                else
+                {
+                    selection.ColumnPosition = Selector.GetColumnPosition();
+                }
+                selection.Caret = Snapshot.CreateTrackingPoint(position);
+                selection.VirtualSpaces = view.Caret.Position.VirtualSpaces;
 
                 if (view.Selection.IsEmpty)
                 {


### PR DESCRIPTION
This PR should fix most issues related to tab characters miscalculating the correct column position.
This also fixes where caret was draw extra thick when on tab characters and also issues where column position was wrongly moved when moving over a line with virtual spaces.