### PR TITLE
Feat: Add option to hold first entry on extension cancel

### DIFF
--- a/src/Classes/Selector.cs
+++ b/src/Classes/Selector.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Operations;
 using Microsoft.VisualStudio.Text.Outlining;
+using SelectNextOccurrence.Options;
 
 namespace SelectNextOccurrence
 {
@@ -585,6 +586,17 @@ namespace SelectNextOccurrence
         /// </summary>
         internal void DiscardSelections()
         {
+            Selections.Clear();
+            HasWrappedDocument = false;
+            view.Caret.IsHidden = false;
+        }
+
+        internal void CancelSelectNextOccurence()
+        {
+            if (ExtensionOptions.Instance.KeepFirstEntry)
+            {
+                view.Caret.MoveTo(Selections.First().Caret.GetPoint(view.TextSnapshot));
+            }
             Selections.Clear();
             HasWrappedDocument = false;
             view.Caret.IsHidden = false;

--- a/src/Commands/CommandTarget.cs
+++ b/src/Commands/CommandTarget.cs
@@ -125,7 +125,7 @@ namespace SelectNextOccurrence.Commands
                         clearSelections = true;
                         break;
                     case VSConstants.VSStd2KCmdID.CANCEL:
-                        Selector.DiscardSelections();
+                        Selector.CancelSelectNextOccurence();
                         break;
                     case VSConstants.VSStd2KCmdID.PAGEDN:
                     case VSConstants.VSStd2KCmdID.PAGEUP:
@@ -156,6 +156,8 @@ namespace SelectNextOccurrence.Commands
                         invokeCommand = true;
                         break;
                     case VSConstants.VSStd2KCmdID.TOGGLE_OVERTYPE_MODE:
+                    case VSConstants.VSStd2KCmdID.TOGGLEVISSPACE:
+                    case VSConstants.VSStd2KCmdID.TOGGLEWORDWRAP:
                         result = NextCommandTarget.Exec(ref pguidCmdGroup, nCmdID, nCmdexecopt, pvaIn, pvaOut);
                         adornmentLayer.DrawAdornments();
                         return result;

--- a/src/Options/ExtensionOptions.cs
+++ b/src/Options/ExtensionOptions.cs
@@ -28,7 +28,8 @@ namespace SelectNextOccurrence.Options
             {
                 ThreadHelper.ThrowIfNotOnUIThread();
 
-                if (instance == null) instance = new ExtensionOptions();
+                if (instance == null)
+                    instance = new ExtensionOptions();
 
                 instance.LoadSettingsFromStorage();
                 return instance;
@@ -41,6 +42,14 @@ namespace SelectNextOccurrence.Options
         [DefaultValue(true)]
         [ExtensionSetting]
         public bool AddMouseCursors { get; set; } = true;
+
+        [Category(Vsix.Name)]
+        [DisplayName("Keep caret on first entry")]
+        [Description("Activate to keep caret on first entry when canceling(pressing escape)")]
+        [DefaultValue(false)]
+        [ExtensionSetting]
+        public bool KeepFirstEntry { get; set; } = false;
+
 
         public override void SaveSettingsToStorage()
         {

--- a/src/SelectNextOccurrencePackage.cs
+++ b/src/SelectNextOccurrencePackage.cs
@@ -12,7 +12,7 @@ namespace SelectNextOccurrence
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
     [InstalledProductRegistration("#110", "#112", Vsix.Version, IconResourceID = 400)] // Info on this package for Help/About
     [ProvideMenuResource("Menus.ctmenu", 1)]
-    [ProvideOptionPage(typeof(ExtensionOptions), Vsix.Name, "Mouse options", 0, 0, true)]
+    [ProvideOptionPage(typeof(ExtensionOptions), Vsix.Name, "General", 0, 0, true)]
     [ProvideAutoLoad(VSConstants.UICONTEXT.NoSolution_string, PackageAutoLoadFlags.BackgroundLoad)]
     [Guid(PackageGuids.guidNextOccurrenceCommandsPackageString)]
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1650:ElementDocumentationMustBeSpelledCorrectly", Justification = "pkgdef, VS and vsixmanifest are valid VS terms")]


### PR DESCRIPTION
Also added 'toggle visible space' and 'toggle word wrap' to list of commands to skip since they where working incorrectly with even numbered selections