### PR TITLE
Fix: Carets in ascending order on start of line not always selecting correctly

### DIFF
--- a/src/Classes/Selector.cs
+++ b/src/Classes/Selector.cs
@@ -214,7 +214,8 @@ namespace SelectNextOccurrence
                     var oldSelections = Selections;
                     Selections = new List<Selection>();
 
-                    foreach (var selection in oldSelections)
+                    // Note: The list is in reverse order to fix a bug in EditorOperations.SelectCurrentWord()
+                    foreach (var selection in oldSelections.OrderByDescending(n => n.Caret.GetPosition(Snapshot)))
                     {
                         if (!selection.IsSelection())
                         {
@@ -276,19 +277,13 @@ namespace SelectNextOccurrence
         {
             EditorOperations.SelectCurrentWord();
 
-            if (EditorOperations.SelectedText.Length != 0)
+            if (EditorOperations.SelectedText.Length != 0
+                && !char.IsLetterOrDigit(EditorOperations.SelectedText[0])
+                && Snapshot.GetLineColumnFromPosition(caretPosition) != 0
+                && char.IsLetterOrDigit(Snapshot[caretPosition - 1]))
             {
-                if (!char.IsLetterOrDigit(EditorOperations.SelectedText[0])
-                    && Snapshot.GetLineColumnFromPosition(caretPosition) != 0)
-                {
-                    var previousChar = Snapshot.ToCharArray(caretPosition - 1, 1)[0];
-
-                    if (char.IsLetterOrDigit(previousChar))
-                    {
-                        view.Caret.MoveTo(caretPosition - 1);
-                        EditorOperations.SelectCurrentWord();
-                    }
-                }
+                view.Caret.MoveTo(caretPosition - 1);
+                EditorOperations.SelectCurrentWord();
             }
 
             AddCurrentSelectionToSelections();


### PR DESCRIPTION
Also minor simplification of SelectCurrentWord